### PR TITLE
Skip provider state setup if state is invalid or missing

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,8 +21,13 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 
       data = loads(self.rfile.read(int(self.headers['Content-Length'])))
 
+      if not data.get('state') or not data.get('params'):
+         self.respond(200, "No state or params found in the request body. Skipping provider state setup.")
+         return
+
       if (matches := graphql_query_state_regex.fullmatch(data['state'])) is None:
-        raise Exception(f'''State not supported: {data['state']}''')
+         self.respond(200, f'''State not supported: {data['state']} - skipping provider state setup.''')
+         return
 
       out_req = Request(
         urljoin(provider_base_url, matches[1]),

--- a/server.py
+++ b/server.py
@@ -21,12 +21,12 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 
       data = loads(self.rfile.read(int(self.headers['Content-Length'])))
 
-      if not data.get('state') or not data.get('params'):
-         self.respond(200, "No state or params found in the request body. Skipping provider state setup.")
+      if 'state' not in data or 'params' not in data:
+         self.respond(200, 'No state or params found in the request body. Skipping provider state setup.')
          return
 
       if (matches := graphql_query_state_regex.fullmatch(data['state'])) is None:
-         self.respond(200, f'''State not supported: {data['state']} - skipping provider state setup.''')
+         self.respond(200, f'''State not supported: "{data['state']}" - skipping provider state setup.''')
          return
 
       out_req = Request(


### PR DESCRIPTION
There are some provider tests that do not need a state setup, which means the Pact file does not have any state or the state is not a GraphQL query. This PR makes the state validation more lenient by skipping the state setup (calling the provider) and just return HTTP 200 so that the provider test doesn't fail.