### PR TITLE
Handle when state = None or params = {}

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 
       data = loads(self.rfile.read(int(self.headers['Content-Length'])))
 
-      if 'state' not in data or 'params' not in data:
+      if not data.get("state") or not data.get("params"):
          self.respond(200, 'No state or params found in the request body. Skipping provider state setup.')
          return
 


### PR DESCRIPTION
Pact verify will send state = null and params = {} if there's no state in Pact file. Hence we need to change the validation to avoid the error.